### PR TITLE
ci: add test workflow for v0.4.3-x release branch

### DIFF
--- a/.github/workflows/release-branch.yml
+++ b/.github/workflows/release-branch.yml
@@ -1,0 +1,28 @@
+name: Release branch tests
+
+# Upstream's ruby.yml only runs on `master`. This workflow runs the test
+# suite for our `v0.4.3-x` release branch and any PR targeting it.
+on:
+  push:
+    branches: [ v0.4.3-x ]
+  pull_request:
+    branches: [ v0.4.3-x ]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Tests
+    runs-on: 'ubuntu-latest'
+    env:
+      BUNDLE_GEMFILE: gemfiles/ci.gemfile
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: '3.3'
+        bundler-cache: true
+    - name: Run tests
+      run: bundle exec rake


### PR DESCRIPTION
## Summary

Adds a simple CI workflow that runs the test suite for the `v0.4.3-x` release branch.

Upstream's existing `ruby.yml` only triggers on pushes/PRs to `master`, so PRs
targeting our `v0.4.3-x` release branch (e.g. #8) currently run **no checks**.
This adds `release-branch.yml`, which runs `bundle exec rake` on pushes and PRs
to `v0.4.3-x`.

## Details

- Single Ruby version (`3.3`) for a fast, simple gate — kept separate from
  upstream's full version matrix so future upstream re-aligns stay clean.
- Uses the existing `gemfiles/ci.gemfile`.
- Scoped strictly to `v0.4.3-x` push/PR events.

Verified locally: `205 runs, 0 failures, 0 errors, 1 skip`.
